### PR TITLE
Fixing Cookies passing to Http Response Meta (was using a cookie filt…

### DIFF
--- a/artemis-network/src/main/java/com/spinn3r/artemis/network/builder/DefaultHttpRequest.java
+++ b/artemis-network/src/main/java/com/spinn3r/artemis/network/builder/DefaultHttpRequest.java
@@ -1,5 +1,12 @@
 package com.spinn3r.artemis.network.builder;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.InetAddress;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
@@ -9,14 +16,6 @@ import com.spinn3r.artemis.network.URLResourceRequest;
 import com.spinn3r.artemis.network.builder.listener.RequestListener;
 import com.spinn3r.artemis.network.cookies.Cookie;
 import com.spinn3r.artemis.network.cookies.Cookies;
-
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.InetAddress;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 /**
  *
@@ -243,7 +242,7 @@ public class DefaultHttpRequest implements HttpRequest {
 
         connect();
 
-        return new DefaultHttpResponseMeta(getResource(), getResourceFromRedirect(), getResponseCode(), getResponseHeadersMap(), Cookies.fromHttpRequest(this) );
+        return new DefaultHttpResponseMeta(getResource(), getResourceFromRedirect(), getResponseCode(), getResponseHeadersMap(), Cookies.toCookieMap(getEffectiveCookies()) );
 
     }
 
@@ -252,7 +251,7 @@ public class DefaultHttpRequest implements HttpRequest {
 
         String contentWithEncoding = getContentWithEncoding();
 
-        return new DefaultHttpContentResponseMeta( getResource(), getResourceFromRedirect(), getResponseCode(), getResponseHeadersMap(), Cookies.fromHttpRequest(this), contentWithEncoding );
+        return new DefaultHttpContentResponseMeta( getResource(), getResourceFromRedirect(), getResponseCode(), getResponseHeadersMap(), Cookies.toCookieMap(getEffectiveCookies()), contentWithEncoding );
 
     }
 

--- a/artemis-network/src/main/java/com/spinn3r/artemis/network/cookies/Cookies.java
+++ b/artemis-network/src/main/java/com/spinn3r/artemis/network/cookies/Cookies.java
@@ -25,6 +25,18 @@ public class Cookies {
 
     }
 
+    public static ImmutableMap<String,Cookie> toCookieMap(List<Cookie> cookies) {
+
+        Map<String, Cookie> result = Maps.newLinkedHashMap();
+
+        for (Cookie cookie : cookies) {
+            result.put(cookie.getName(), cookie);
+        }
+
+        return ImmutableMap.copyOf(result);
+
+    }
+    
     public static ImmutableMap<String,Cookie> fromHttpRequest( HttpRequest httpRequest ) {
         return fromResponseHeadersMap( httpRequest.getResponseHeadersMap() );
     }


### PR DESCRIPTION
Cookies.fromHttpRequest builds cookies from HttpRequest headers, although that list filters off all "Set-Cookie" headers, so it is always becomes empty in the end.

There is a comment on that filter saying using cookies there could cause impacts, so the simpler solution was building up an actual cookie map without changing much code base.